### PR TITLE
Update and rename slicer-nightly.rb to slicer-preview.rb

### DIFF
--- a/Casks/slicer-preview.rb
+++ b/Casks/slicer-preview.rb
@@ -1,4 +1,4 @@
-cask "slicer-nightly" do
+cask "slicer-preview" do
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
The name of this version of Slicer changed from _Nightly_ to _Preview_ some months ago.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

---

Offense reported by `brew cask style`:

```ruby
slicer-preview.rb:1:1: C: Missing frozen string literal comment.
cask "slicer-preview" do
^

1 file inspected, 1 offense detected, 1 more offense can be corrected with `rubocop -A`
Error: Style check failed.
```